### PR TITLE
add pncA p.Gly108Glu

### DIFF
--- a/tbdb.csv
+++ b/tbdb.csv
@@ -1927,6 +1927,7 @@ pncA,p.Gly105Arg,pyrazinamide,resistance,,,Uncertain significance
 pncA,p.Gly105Asp,pyrazinamide,resistance,,,Assoc w R - interim
 pncA,p.Gly105Val,pyrazinamide,resistance,,,Assoc w R
 pncA,p.Gly108Arg,pyrazinamide,resistance,,,Assoc w R - interim
+pncA,p.Gly108Glu,pyrazinamide,resistance,,,Uncertain significance
 pncA,p.Gly132Ala,pyrazinamide,resistance,,,Assoc w R
 pncA,p.Gly132Asp,pyrazinamide,resistance,,,Assoc w R - interim
 pncA,p.Gly132Ser,pyrazinamide,resistance,,,Assoc w R


### PR DESCRIPTION
Dear Jody,

we had an MTB isolate with pyrazinamide resistance confirmed by two culture-based phenotypic drug susceptibility tests (on at Labor Berlin and one at the NRC in Borstel).

TB-Profiler identified the mutation `pncA p.Gly108Glu` in the Other variants report:
```
2288919	Rv2043c	pncA	missense_variant	p.Gly108Glu	0.989	type=who_confidence|drug=pyrazinamide|who_confidence=Uncertain significance
```
`p.Gly108Glu` was not previously contained in TBDB. However, `p.Gly108Arg` is already in TBDB.

So I think, we should add `p.Gly108Glu`.
