### PR TITLE
Remove two ahpC mutations 

### DIFF
--- a/tbdb.csv
+++ b/tbdb.csv
@@ -1242,8 +1242,6 @@ ahpC,c.-66G>A,isoniazid,resistance,,,
 ahpC,c.-74G>A,isoniazid,resistance,,,Uncertain significance
 ahpC,c.-81C>T,isoniazid,resistance,,,Uncertain significance
 ahpC,p.Asp33Asn,isoniazid,resistance,,,
-ahpC,p.Asp73His,isoniazid,resistance,,,Uncertain significance
-ahpC,p.Glu76Lys,isoniazid,resistance,,,Uncertain significance
 ahpC,p.Leu191Arg,isoniazid,resistance,,,Uncertain significance
 ahpC,p.Phe10Ile,isoniazid,resistance,,,
 ahpC,p.Pro2Ser,isoniazid,resistance,,,


### PR DESCRIPTION
Lack of evidence for Asp73His and Glu76Lys has been highlighted. The original source for these mutations was the TBDreaMDB website which listed drug resistance mutations but has since stopped operating. These mutations were investigated with a dataset of 50,722 samples for which Illumina WGS was available.

# Asp73His

All of the samples with this mutation are lineage1.2.2.2 strains (86/86). A phylogenetic tree with the branch length representing the number of mutations occuring on each branch seems to indicate that this mutation is a phylogenetic mutation that would have predated the introduction of isoniazid.

![Asp73His](https://user-images.githubusercontent.com/8697224/213164980-db4c79e2-cb7d-427c-8292-cf3709699b62.svg)

# Glu76Lys

The majority of the samples with this mutation are lineage1.2.2.2 strains (61/66). A phylogenetic tree with the branch length representing the number of mutations occuring on each branch seems to indicate that this mutation is a phylogenetic mutation that would have predated the introduction of isoniazid.

![Glu76Lys](https://user-images.githubusercontent.com/8697224/213165274-602dd748-cc9f-4c06-ae3f-8502d562d967.svg)


