### PR TITLE
remove P454L

### DIFF
--- a/tbdb.csv
+++ b/tbdb.csv
@@ -2208,7 +2208,6 @@ rpoB,p.Phe433Leu,rifampicin,resistance,,,
 rpoB,p.Phe433Val,rifampicin,resistance,,,
 rpoB,p.Pro454Arg,rifampicin,resistance,,,Uncertain significance
 rpoB,p.Pro454His,rifampicin,resistance,,,Uncertain significance
-rpoB,p.Pro454Leu,rifampicin,resistance,,,Uncertain significance
 rpoB,p.Pro454Ser,rifampicin,resistance,,,Uncertain significance
 rpoB,p.Pro483Leu,rifampicin,resistance,,,Uncertain significance
 rpoB,p.Ser428Arg,rifampicin,resistance,,,Assoc w R - interim


### PR DESCRIPTION
There is lack of evidence for P454L. It is often found co-occuring with other resistance mutations. In the cases where it occurs alone, the strains have a sensitive DST.