### PR TITLE
add mmA3 p.Gly98Asp

### DIFF
--- a/watchlist.csv
+++ b/watchlist.csv
@@ -117,3 +117,4 @@ atpE,drug_resistance,bedaquiline
 gyrB,drug_resistance,levofloxacin
 Rv0010c,drug_resistance,isoniazid
 fbiB,drug_resistance,clofazimine
+mmaA3,drug_resistance,isoniazid


### PR DESCRIPTION
This point mutation can lead to low-level INH resistance
and has been observed in M. bovis BCG strains, see
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4614345/